### PR TITLE
Add a program to create initial config

### DIFF
--- a/goose-init
+++ b/goose-init
@@ -84,12 +84,18 @@ extensions:
     display_name: Todo
     bundled: true
     available_tools: []
-GOOSE_PROVIDER: google
-GOOSE_MODE: smartapprove
-GOOSE_MODEL: gemini-2.5-flash
+GOOSE_CONTEXT_STRATEGY: prompt
+GOOSE_DISABLE_SESSION_NAMING: true
+GOOSE_MAX_TOKENS: 16000
+GOOSE_MAX_TURNS: 200
+GOOSE_MODE: approve
+GOOSE_MOIM_MESSAGE_TEXT: "You are a Red Hat Enterprise Linux expert."
+GOOSE_RANDOM_THINKING_MESSAGES: false
+GOOSE_SUBAGENT_MAX_TURNS: 25
 GOOSE_TELEMETRY_ENABLED: false
-GOOSE_ALLOWLIST: ""
+OTEL_SDK_DISABLED: true
 SECURITY_PROMPT_ENABLED: true
+SECURITY_PROMPT_THRESHOLD: 0.9
 """.lstrip()
 
 

--- a/goose-init
+++ b/goose-init
@@ -27,6 +27,15 @@ extensions:
     display_name: Extension Manager
     bundled: true
     available_tools: []
+  developer:
+    enabled: false
+    type: builtin
+    name: developer
+    description: Write and edit files, and execute shell commands
+    display_name: Developer
+    timeout: null
+    bundled: true
+    available_tools: []
   apps:
     enabled: false
     type: platform

--- a/goose-init
+++ b/goose-init
@@ -11,7 +11,7 @@ extensions:
     type: stdio
     name: linux-tools
     description: Linux Tools
-    cmd: /usr/bin/linux-mcp-server
+    cmd: linux-mcp-server
     args: []
     envs:
       LINUX_MCP_ALLOWED_LOG_PATHS: /var/log/messages
@@ -75,10 +75,15 @@ def main():
 
     if not config.exists():
         config.write_text(DEFAULT_CONFIG)
-
-    if args.overwrite:
+    elif args.overwrite:
         backup_config(config)
         config.write_text(DEFAULT_CONFIG)
+    else:
+        print(
+            f"Found existing configuration at {config}. To backup and overwrite this configuration, run with '--overwrite'."
+        )
+
+    print(f"Wrote configuration to {config}.")
 
 
 if __name__ == "__main__":

--- a/goose-init
+++ b/goose-init
@@ -53,7 +53,7 @@ extensions:
     bundled: true
     available_tools: []
   chatrecall:
-    enabled: false
+    enabled: true
     type: platform
     name: chatrecall
     description: Search past conversations and load session summaries for contextual memory

--- a/goose-init
+++ b/goose-init
@@ -19,7 +19,62 @@ extensions:
     timeout: 30
     bundled: null
     available_tools: []
-
+  extensionmanager:
+    enabled: true
+    type: platform
+    name: Extension Manager
+    description: Enable extension management tools for discovering, enabling, and disabling extensions
+    display_name: Extension Manager
+    bundled: true
+    available_tools: []
+  apps:
+    enabled: false
+    type: platform
+    name: apps
+    description: Create and manage custom Goose apps through chat. Apps are HTML/CSS/JavaScript and run in sandboxed windows.
+    display_name: Apps
+    bundled: true
+    available_tools: []
+  summon:
+    enabled: false
+    type: platform
+    name: summon
+    description: Load knowledge and delegate tasks to subagents
+    display_name: Summon
+    bundled: true
+    available_tools: []
+  chatrecall:
+    enabled: false
+    type: platform
+    name: chatrecall
+    description: Search past conversations and load session summaries for contextual memory
+    display_name: Chat Recall
+    bundled: true
+    available_tools: []
+  code_execution:
+    enabled: false
+    type: platform
+    name: code_execution
+    description: Goose will make extension calls through code execution, saving tokens
+    display_name: Code Mode
+    bundled: true
+    available_tools: []
+  tom:
+    enabled: false
+    type: platform
+    name: tom
+    description: Inject custom context into every turn via GOOSE_MOIM_MESSAGE_TEXT and GOOSE_MOIM_MESSAGE_FILE environment variables
+    display_name: Top Of Mind
+    bundled: true
+    available_tools: []
+  todo:
+    enabled: false
+    type: platform
+    name: todo
+    description: Enable a todo list for goose so it can keep track of what it is doing
+    display_name: Todo
+    bundled: true
+    available_tools: []
 GOOSE_PROVIDER: google
 GOOSE_MODE: smartapprove
 GOOSE_MODEL: gemini-2.5-flash

--- a/goose-init
+++ b/goose-init
@@ -128,6 +128,7 @@ def main():
     args = parse_args()
     config = args.config
 
+    config.parent.mkdir(parents=True, exist_ok=True)
     if not config.exists():
         config.write_text(DEFAULT_CONFIG)
     elif args.overwrite:

--- a/goose-init
+++ b/goose-init
@@ -129,16 +129,17 @@ def main():
     config = args.config
 
     config.parent.mkdir(parents=True, exist_ok=True)
-    if not config.exists():
-        config.write_text(DEFAULT_CONFIG)
-    elif args.overwrite:
-        backup_config(config)
-        config.write_text(DEFAULT_CONFIG)
-    else:
-        print(
-            f"Found existing configuration at {config}. To backup and overwrite this configuration, run with '--overwrite'."
-        )
+    if config.exists():
+        if not args.overwrite:
+            print(
+                f"Found existing configuration at {config}. "
+                "To backup the current config and write a new config, run with '--overwrite'."
+            )
+            return
 
+        backup_config(config)
+
+    config.write_text(DEFAULT_CONFIG)
     print(f"Wrote configuration to {config}.")
 
 

--- a/goose-init
+++ b/goose-init
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+
+import argparse
+import pathlib
+import shutil
+
+DEFAULT_CONFIG = """
+extensions:
+  linux-tools:
+    enabled: true
+    type: stdio
+    name: linux-tools
+    description: Linux Tools
+    cmd: /usr/bin/linux-mcp-server
+    args: []
+    envs:
+      LINUX_MCP_ALLOWED_LOG_PATHS: /var/log/messages
+    env_keys: []
+    timeout: 30
+    bundled: null
+    available_tools: []
+
+GOOSE_PROVIDER: google
+GOOSE_MODE: smartapprove
+GOOSE_MODEL: gemini-2.5-flash
+GOOSE_TELEMETRY_ENABLED: false
+GOOSE_ALLOWLIST: ""
+SECURITY_PROMPT_ENABLED: true
+""".lstrip()
+
+
+def backup_config(config_path: pathlib.Path, max_backups: int = 5):
+    config_path = pathlib.Path(config_path).expanduser()
+    if not config_path.exists():
+        return
+
+    backup = config_path.with_suffix(f"{config_path.suffix}.bak")
+    for n in range(max_backups, 1, -1):
+        # Rotate backup files
+        older = backup.with_suffix(f".bak.{n - 1}")
+        newer = config_path.with_suffix(f"{config_path.suffix}.bak.{n}")
+        if older.exists():
+            shutil.move(older, newer)
+
+    if backup.exists():
+        shutil.move(backup, backup.with_suffix(".bak.1"))
+
+    shutil.copy2(config_path, backup)
+
+    # Cleanup stale backups
+    for i in range(max_backups + 1, max_backups + 10):
+        stale = config_path.with_suffix(f".bak.{i}")
+        if stale.exists():
+            stale.unlink()
+        else:
+            break
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=pathlib.Path,
+        default=pathlib.Path("~/.config/goose/config.yaml").expanduser(),
+    )
+    parser.add_argument("-o", "--overwrite", action="store_true")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    config = args.config
+
+    if not config.exists():
+        config.write_text(DEFAULT_CONFIG)
+
+    if args.overwrite:
+        backup_config(config)
+        config.write_text(DEFAULT_CONFIG)
+
+
+if __name__ == "__main__":
+    main()

--- a/goose-init.sh
+++ b/goose-init.sh
@@ -97,9 +97,8 @@ EOF
 CONFIG_DIR="${HOME}/.config/goose"
 CONFIG_FILE="${CONFIG_DIR}/config.yaml"
 
-if [[ -f "${CONFIG_FILE}" ]]; then
-    exit 0
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  mkdir -p "${CONFIG_DIR}"
+  printf '%s\n' "${DEFAULT_CONFIG}" > "${CONFIG_FILE}"
 fi
 
-mkdir -p "${CONFIG_DIR}"
-printf '%s\n' "${DEFAULT_CONFIG}" > "${CONFIG_FILE}"

--- a/goose-init.sh
+++ b/goose-init.sh
@@ -1,10 +1,6 @@
-#!/usr/bin/python3
+#!/bin/bash
 
-import argparse
-import pathlib
-import shutil
-
-DEFAULT_CONFIG = """
+read -r -d '' DEFAULT_CONFIG << 'EOF'
 extensions:
   linux-tools:
     enabled: true
@@ -96,67 +92,14 @@ GOOSE_TELEMETRY_ENABLED: false
 OTEL_SDK_DISABLED: true
 SECURITY_PROMPT_ENABLED: true
 SECURITY_PROMPT_THRESHOLD: 0.9
-""".lstrip()
+EOF
 
+CONFIG_DIR="${HOME}/.config/goose"
+CONFIG_FILE="${CONFIG_DIR}/config.yaml"
 
-def backup_config(config_path: pathlib.Path, max_backups: int = 5):
-    config_path = pathlib.Path(config_path).expanduser()
-    if not config_path.exists():
-        return
+if [[ -f "${CONFIG_FILE}" ]]; then
+    exit 0
+fi
 
-    backup = config_path.with_suffix(f"{config_path.suffix}.bak")
-    for n in range(max_backups, 1, -1):
-        # Rotate backup files
-        older = backup.with_suffix(f".bak.{n - 1}")
-        newer = config_path.with_suffix(f"{config_path.suffix}.bak.{n}")
-        if older.exists():
-            shutil.move(older, newer)
-
-    if backup.exists():
-        shutil.move(backup, backup.with_suffix(".bak.1"))
-
-    shutil.copy2(config_path, backup)
-
-    # Cleanup stale backups
-    for i in range(max_backups + 1, max_backups + 10):
-        stale = config_path.with_suffix(f".bak.{i}")
-        if stale.exists():
-            stale.unlink()
-        else:
-            break
-
-
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-c",
-        "--config",
-        type=pathlib.Path,
-        default=pathlib.Path("~/.config/goose/config.yaml").expanduser(),
-    )
-    parser.add_argument("-o", "--overwrite", action="store_true")
-
-    return parser.parse_args()
-
-
-def main():
-    args = parse_args()
-    config = args.config
-
-    config.parent.mkdir(parents=True, exist_ok=True)
-    if config.exists():
-        if not args.overwrite:
-            print(
-                f"Found existing configuration at {config}. "
-                "To backup the current config and write a new config, run with '--overwrite'."
-            )
-            return
-
-        backup_config(config)
-
-    config.write_text(DEFAULT_CONFIG)
-    print(f"Wrote configuration to {config}.")
-
-
-if __name__ == "__main__":
-    main()
+mkdir -p "${CONFIG_DIR}"
+printf '%s\n' "${DEFAULT_CONFIG}" > "${CONFIG_FILE}"

--- a/goose-init.sh
+++ b/goose-init.sh
@@ -102,3 +102,6 @@ if [[ ! -f "${CONFIG_FILE}" ]]; then
   printf '%s\n' "${DEFAULT_CONFIG}" > "${CONFIG_FILE}"
 fi
 
+unset CONFIG_DIR
+unset CONFIG_FILE
+unset DEFAULT_CONFIG

--- a/goose.spec
+++ b/goose.spec
@@ -404,7 +404,9 @@ export RUSTONIG_SYSTEM_LIBONIG=1
 %install
 install -Dpm 0755 target/rpm/goose -t %{buildroot}%{_bindir}
 install -Dpm 0755 target/rpm/goosed -t %{buildroot}%{_bindir}
+%if %{?rhel:%{rhel}}%{!?rhel:0} >= 9 || %{?epel:%{epel}}%{!?epel:0} >= 9
 install -Dpm 0755 goose-init -t %{buildroot}%{_bindir}
+%endif
 
 %if %{with check}
 %check
@@ -443,7 +445,8 @@ skip="${skip-} --skip scenario_tests::scenarios::tests::test_image_analysis"
 
 %{_bindir}/goose
 %{_bindir}/goosed
-%{_bindir}/goose-init
+%if %{?rhel:%{rhel}}%{!?rhel:0} >= 9 || %{?epel:%{epel}}%{!?epel:0} >= 9
+%endif
 
 %changelog
 %autochangelog

--- a/goose.spec
+++ b/goose.spec
@@ -30,7 +30,7 @@ Source4:        d3-sankey.license
 Source5:        leaflet.license
 Source6:        leaflet-markercluster.license
 Source7:        mermaid.license
-Source8:        goose-init
+Source8:        goose-init.sh
 # This script is used to generate the vendor tarball for goose, and while it
 # does not offer any practical/real usage for the application, it helps us to
 # easily generate the vendored tarball and apply the correct patches while
@@ -405,7 +405,7 @@ export RUSTONIG_SYSTEM_LIBONIG=1
 install -Dpm 0755 target/rpm/goose -t %{buildroot}%{_bindir}
 install -Dpm 0755 target/rpm/goosed -t %{buildroot}%{_bindir}
 %if %{?rhel:%{rhel}}%{!?rhel:0} >= 9 || %{?epel:%{epel}}%{!?epel:0} >= 9
-install -Dpm 0755 goose-init -t %{buildroot}%{_bindir}
+install -Dpm 0755 %{SOURCE8} %{buildroot}%{_sysconfdir}/profile.d/goose-init.sh
 %endif
 
 %if %{with check}
@@ -446,7 +446,8 @@ skip="${skip-} --skip scenario_tests::scenarios::tests::test_image_analysis"
 %{_bindir}/goose
 %{_bindir}/goosed
 %if %{?rhel:%{rhel}}%{!?rhel:0} >= 9 || %{?epel:%{epel}}%{!?epel:0} >= 9
-%{_bindir}/goose-init  # Program for creating default Red Hat recommended config
+# Creates default Red Hat recommended config if needed
+%{_sysconfdir}/profile.d/goose-init.sh
 %endif
 
 %changelog

--- a/goose.spec
+++ b/goose.spec
@@ -30,6 +30,7 @@ Source4:        d3-sankey.license
 Source5:        leaflet.license
 Source6:        leaflet-markercluster.license
 Source7:        mermaid.license
+Source8:        goose-init
 # This script is used to generate the vendor tarball for goose, and while it
 # does not offer any practical/real usage for the application, it helps us to
 # easily generate the vendored tarball and apply the correct patches while
@@ -403,6 +404,7 @@ export RUSTONIG_SYSTEM_LIBONIG=1
 %install
 install -Dpm 0755 target/rpm/goose -t %{buildroot}%{_bindir}
 install -Dpm 0755 target/rpm/goosed -t %{buildroot}%{_bindir}
+install -Dpm 0755 goose-init -t %{buildroot}%{_bindir}
 
 %if %{with check}
 %check
@@ -441,6 +443,7 @@ skip="${skip-} --skip scenario_tests::scenarios::tests::test_image_analysis"
 
 %{_bindir}/goose
 %{_bindir}/goosed
+%{_bindir}/goose-init
 
 %changelog
 %autochangelog

--- a/goose.spec
+++ b/goose.spec
@@ -446,6 +446,7 @@ skip="${skip-} --skip scenario_tests::scenarios::tests::test_image_analysis"
 %{_bindir}/goose
 %{_bindir}/goosed
 %if %{?rhel:%{rhel}}%{!?rhel:0} >= 9 || %{?epel:%{epel}}%{!?epel:0} >= 9
+%{_bindir}/goose-init  # Program for creating default Red Hat recommended config
 %endif
 
 %changelog


### PR DESCRIPTION
Add a `goose-init.sh` script to `/etc/profile.d` that will create the default goose config with recommended settings if it does not exist. It operates silently and has no mechanism for overwriting or backing up the existing config.

It can be run directly with `./goose-init.sh`.

This is currently `bash` only since it uses a here document to store the config. There's a somewhat clean way to do this in `bash` but not clean way to do this in `csh`.

If we want to have a script for `csh` as well, we'll need to store the config file outside of the script so it can be read from a file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added initialization script that automatically sets up Goose configuration directory and default settings on first run.
  * Updated RPM packaging to include initialization script for RHEL 9+ compatible distributions, enabling seamless configuration setup during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->