### PR TITLE
Fix CVE-2026-33056 for tar dependency

### DIFF
--- a/0001-Patch-windows-dependencies-across-workspace.patch
+++ b/0001-Patch-windows-dependencies-across-workspace.patch
@@ -1,7 +1,7 @@
-From b605b140bbb7cf72e7697aae58525e71282ea388 Mon Sep 17 00:00:00 2001
+From 66c8648cc96c66dce3de852c306fc535873270ee Mon Sep 17 00:00:00 2001
 From: Rodolfo Olivieri <rodolfo.olivieri3@gmail.com>
 Date: Wed, 4 Feb 2026 08:14:50 -0300
-Subject: [PATCH 1/3] Patch windows dependencies across workspace
+Subject: [PATCH 1/4] Patch windows dependencies across workspace
 
 Removed the following windows dependencies across the crates workspaces
 members as they are platform specific (windows)
@@ -27,7 +27,7 @@ against the dbus library
  5 files changed, 3 insertions(+), 112 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 4b9e2e1f9..c4e6040ac 100644
+index e2808819b..1d99b76fd 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -1945,7 +1945,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/0002-Disable-rustls-and-default-features-for-some-librari.patch
+++ b/0002-Disable-rustls-and-default-features-for-some-librari.patch
@@ -1,7 +1,7 @@
-From dbd2529d89f3df21c3b72db7a5d9f7f52b459309 Mon Sep 17 00:00:00 2001
+From a46d7d8d988c37451ec489edb6627dbaf6cf02d3 Mon Sep 17 00:00:00 2001
 From: Rodolfo Olivieri <rodolfo.olivieri3@gmail.com>
 Date: Tue, 10 Feb 2026 12:06:30 -0300
-Subject: [PATCH 2/3] Disable rustls and default-features for some libraries
+Subject: [PATCH 2/4] Disable rustls and default-features for some libraries
 
 * Removed rustls features from reqwest, sqlx, tokio-tungstenite
 * Added runtime-tokio-native-tls feature for sqlx as the original one
@@ -30,7 +30,7 @@ Subject: [PATCH 2/3] Disable rustls and default-features for some libraries
  4 files changed, 155 insertions(+), 517 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index c4e6040ac..9eb155b9d 100644
+index 1d99b76fd..938371d52 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -169,12 +169,6 @@ dependencies = [

--- a/0003-Patch-code-to-use-native-tls-instead-of-rustls.patch
+++ b/0003-Patch-code-to-use-native-tls-instead-of-rustls.patch
@@ -1,7 +1,7 @@
-From 567c4190b626a7e25d9126101377ccd00b123791 Mon Sep 17 00:00:00 2001
+From c84ef27423275d1de3688322d04ccf0f863fbead Mon Sep 17 00:00:00 2001
 From: Rodolfo Olivieri <rodolfo.olivieri3@gmail.com>
 Date: Tue, 10 Feb 2026 12:07:23 -0300
-Subject: [PATCH 3/3] Patch code to use native-tls instead of rustls
+Subject: [PATCH 3/4] Patch code to use native-tls instead of rustls
 
 * Remove rustls default provider installation from lapstone tunnel
 * Patched providers/api_cilent.rs to allow using from_pkcs8_pem due to

--- a/0004-Fix-for-CVE-2026-33056-on-tar.patch
+++ b/0004-Fix-for-CVE-2026-33056-on-tar.patch
@@ -1,0 +1,46 @@
+From d0841e2e84dea05566a564bf4957b5bcfea0de13 Mon Sep 17 00:00:00 2001
+From: Rodolfo Olivieri <rodolfo.olivieri3@gmail.com>
+Date: Mon, 23 Mar 2026 13:42:36 -0300
+Subject: [PATCH 4/4] Fix for CVE-2026-33056 on tar
+
+Since we have bundled dependencies, this patch is updating the version
+of patch in crates/goose-cli/Cargo.toml to install this specific version
+
+Closes: rhbz#2449678
+---
+ Cargo.lock                  | 4 ++--
+ crates/goose-cli/Cargo.toml | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 938371d52..12d8defd8 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -6885,9 +6885,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+ 
+ [[package]]
+ name = "tar"
+-version = "0.4.44"
++version = "0.4.45"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
++checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+ dependencies = [
+  "filetime",
+  "libc",
+diff --git a/crates/goose-cli/Cargo.toml b/crates/goose-cli/Cargo.toml
+index 1e85d2318..92e12d9ee 100644
+--- a/crates/goose-cli/Cargo.toml
++++ b/crates/goose-cli/Cargo.toml
+@@ -44,7 +44,7 @@ shlex = "1.3.0"
+ async-trait = "0.1.89"
+ base64 = { workspace = true }
+ regex = "1.11.1"
+-tar = "0.4"
++tar = "0.4.45"
+ # Web server dependencies
+ axum = { version = "0.8.1", features = ["ws", "macros"] }
+ tower-http = { workspace = true, features = ["cors", "fs", "auth"] }
+-- 
+2.53.0
+

--- a/generate-vendor-tarball.sh
+++ b/generate-vendor-tarball.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # List of patches to be applied in the vendored folder
-PATCHES=("0001-Patch-windows-dependencies-across-workspace.patch" "0002-Disable-rustls-and-default-features-for-some-librari.patch")
+PATCHES=("0001-Patch-windows-dependencies-across-workspace.patch" "0002-Disable-rustls-and-default-features-for-some-librari.patch" "0004-Fix-for-CVE-2026-33056-on-tar.patch")
 
 check_required_tools() {
     local tools=("cargo" "rpmspec" "spectool" "tar" "patch")

--- a/goose.spec
+++ b/goose.spec
@@ -47,6 +47,9 @@ Patch1:         0002-Disable-rustls-and-default-features-for-some-librari.patch
 # re-create the dependencies patch easily without having to modify source code
 # when a new version is pushed.
 Patch2:         0003-Patch-code-to-use-native-tls-instead-of-rustls.patch
+# Downstream patch to update tar for version 0.4.45. This patch can be dropped
+# once https://issues.redhat.com/browse/RSPEED-2434 is fixed.
+Patch3:         0004-Fix-for-CVE-2026-33056-on-tar.patch
 # Patch the `build.rs` for `ring` crate to avoid using the pre-generated object
 # files that comes with the vendored crate, and instead, build from system
 # libraries.


### PR DESCRIPTION
Closes: rhbz#2449678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Patched CVE-2026-33056 in the tar dependency.

* **Chores**
  * Switched TLS defaults to native-tls for broader platform compatibility.
  * Removed Windows-only dependency usage across the workspace.
  * Updated dependency versions and regenerated lockfiles.
  * Added the downstream patch to the RPM packaging flow and ensured patch application in the vendor tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->