### PR TITLE
Run targets on a schedule

### DIFF
--- a/.github/workflows/scheduled-copr-build.yml
+++ b/.github/workflows/scheduled-copr-build.yml
@@ -1,0 +1,34 @@
+name: Scheduled Copr Build
+
+on:
+  schedule:
+    # Run daily at midnight UTC
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  copr-build:
+    name: Trigger Copr Builds
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+
+      - uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: pip install --requirement requirements/requirements-copr-builds-3.14.txt
+
+      - name: Trigger builds
+        env:
+          COPR_LOGIN: ${{ secrets.COPR_LOGIN }}
+          COPR_TOKEN: ${{ secrets.COPR_TOKEN }}
+          COPR_USERNAME: ${{ secrets.COPR_USERNAME }}
+        run: ./scripts/trigger_builds.py --no-monitor

--- a/.github/workflows/scheduled-copr-build.yml
+++ b/.github/workflows/scheduled-copr-build.yml
@@ -2,8 +2,8 @@ name: Scheduled Copr Build
 
 on:
   schedule:
-    # Run daily at midnight UTC
-    - cron: "0 0 * * *"
+    # Run weekly on Monday at midnight UTC
+    - cron: "0 0 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/scheduled-copr-build.yml
+++ b/.github/workflows/scheduled-copr-build.yml
@@ -31,4 +31,4 @@ jobs:
           COPR_LOGIN: ${{ secrets.COPR_LOGIN }}
           COPR_TOKEN: ${{ secrets.COPR_TOKEN }}
           COPR_USERNAME: ${{ secrets.COPR_USERNAME }}
-        run: ./scripts/trigger_builds.py --no-monitor
+        run: ./scripts/trigger_builds.py

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,7 @@ logs:
 .PHONY: sync
 sync:
 	scp $(FILES_TO_SYNC) $(FAS_USERNAME)@fedorapeople.org:/home/fedora/$(FAS_USERNAME)/public_html/$(NAME)
+
+.PHONY: freeze
+freeze:
+	./scripts/freeze.py --python-versions 3.14

--- a/requirements/requirements-copr-builds-3.14.txt
+++ b/requirements/requirements-copr-builds-3.14.txt
@@ -1,0 +1,14 @@
+certifi==2026.4.22
+charset-normalizer==3.4.7
+copr==2.6
+filelock==3.29.0
+idna==3.13
+markdown-it-py==4.2.0
+mdurl==0.1.2
+munch==4.0.0
+Pygments==2.20.0
+requests==2.33.1
+requests-toolbelt==1.0.0
+rich==15.0.0
+setuptools==82.0.1
+urllib3==2.7.0

--- a/requirements/requirements-copr-builds.in
+++ b/requirements/requirements-copr-builds.in
@@ -1,0 +1,2 @@
+copr
+rich

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,10 @@
+line-length = 120
+indent-width = 4
+target-version = "py312"
+
+[lint.isort]
+case-sensitive = false
+force-single-line = true
+lines-after-imports = 2
+lines-between-types = 1
+order-by-type = false

--- a/scripts/freeze.py
+++ b/scripts/freeze.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+import argparse
+import shutil
+import subprocess
+
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+
+def freeze(python_version: str, requirement: Path) -> str:
+    print(f"🥶 Freezing Python {python_version} {requirement.stem}...", flush=True)
+
+    python_bin = shutil.which(f"python{python_version}")
+    if python_bin is None:
+        return f"Unable to find Python{python_version}"
+
+    python_bin = Path(python_bin)
+
+    repo_root = requirement.parent.parent
+    venv_path = repo_root / ".venvs" / f"freezer-{requirement.stem}-{python_version}"
+    venv_python = venv_path / "bin" / "python"
+    constraints = repo_root / "requirements" / f"{requirement.stem}-constraints.txt"
+    freeze_file = repo_root / "requirements" / f"{requirement.stem}-{python_version}.txt"
+
+    # Create a fresh virtual environment
+    subprocess.check_output([python_bin, "-m", "venv", "--clear", venv_path])
+    subprocess.check_output([venv_python, "-m", "pip", "install", "--upgrade", "pip"])
+
+    constraint_args = []
+    if constraints.is_file():
+        constraint_args = ["--constraint", constraints]
+
+    # Install requirements
+    subprocess.check_output(
+        [
+            venv_python,
+            "-m",
+            "pip",
+            "--no-cache-dir",
+            "install",
+            "--requirement",
+            requirement,
+            *constraint_args,
+        ]
+    )
+
+    # Generate a freeze file
+    result = subprocess.run([venv_python, "-m", "pip", "freeze"], check=True, capture_output=True)
+    freeze_file.write_bytes(result.stdout)
+
+    return f"✅ {requirement.stem}-{python_version} complete"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--python-versions", default="3.10,3.12,3.13,3.14")
+    parser.add_argument("-r", "--requirement", default="requirements")
+
+    return parser.parse_args()
+
+
+def sort_versions(versions: str) -> list[str]:
+    def list_of_parts(items):
+        return [int(n) for n in items.split(".")]
+
+    stripped_versions = [version.strip() for version in versions.split(",")]
+
+    return sorted(stripped_versions, key=list_of_parts)
+
+
+def main():
+    args = parse_args()
+    file = Path(__file__)
+    repo_root = file.parent.parent
+    requirements = list(repo_root.joinpath(args.requirement).glob("*.in"))
+    python_versions = sort_versions(args.python_versions)
+    workers = len(requirements) * len(python_versions)
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [
+            executor.submit(freeze, py_ver, req)
+            for req in requirements
+            for py_ver in python_versions  # noformat
+        ]
+    for future in as_completed(futures):
+        print(future.result())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trigger_builds.py
+++ b/scripts/trigger_builds.py
@@ -50,7 +50,7 @@ class Targeter:
 
     fedora_versions: t.Iterable[str] = ("43", "44", "rawhide")
     rhel_versions: t.Iterable[str] = ("9", "10")
-    architectures: t.Iterable[str] = ("x86_64", "aarch64", "s390x", "ppc64le", "s390x")
+    architectures: t.Iterable[str] = ("x86_64", "aarch64", "s390x", "ppc64le")
     chroots: t.Iterable[str] = dataclasses.field(init=False)
 
     def __post_init__(self):

--- a/scripts/trigger_builds.py
+++ b/scripts/trigger_builds.py
@@ -27,35 +27,21 @@ OWNER = "@rhel-lightspeed"
 PROJECT = "goose"
 PACKAGE = "goose"
 
-CHROOTS = [
-    "fedora-43-x86_64",
-    "fedora-43-aarch64",
-    "fedora-43-ppc64le",
-    "fedora-43-s390x",
-    "fedora-44-x86_64",
-    "fedora-44-aarch64",
-    "fedora-44-ppc64le",
-    "fedora-44-s390x",
-    "fedora-rawhide-x86_64",
-    "fedora-rawhide-aarch64",
-    "fedora-rawhide-ppc64le",
-    "fedora-rawhide-s390x",
-    "epel-9-x86_64",
-    "epel-9-aarch64",
-    "epel-9-ppc64le",
-    "epel-9-s390x",
-    "epel-10-x86_64",
-    "epel-10-aarch64",
-    "epel-10-ppc64le",
-    "epel-10-s390x",
-    "rhel-9-x86_64",
-    "rhel-9-aarch64",
-    "rhel-9-s390x",
-    "rhel-10-x86_64",
-    "rhel-10-aarch64",
-    "rhel-10-s390x",
-    "rhel-10-ppc64le",
-]
+FEDORA_MAJOR_VERSIONS = ("43", "44", "rawhide")
+RHEL_MAJOR_VERSIONS = ("9", "10")
+ARCH = (
+    "x86_64",
+    "aarch64",
+    "s390x",
+    "ppc64le",
+    "s390x",
+)
+TARGETS = (
+    *[f"fedora-{ver}" for ver in FEDORA_MAJOR_VERSIONS],
+    *[f"{dist}-{ver}" for dist in ("epel", "rhel") for ver in RHEL_MAJOR_VERSIONS],
+)
+CHROOTS = [f"{target}-{arch}" for target in TARGETS for arch in ARCH]
+
 
 TERMINAL_STATES = {"succeeded", "failed", "canceled", "forked"}
 
@@ -189,10 +175,11 @@ def main() -> None:
         "chroots",
         nargs="*",
         help="Chroots to build for. If not specified, all chroots are used.",
+        default=CHROOTS,
     )
     args = parser.parse_args()
 
-    chroots = args.chroots or CHROOTS
+    chroots = args.chroots
 
     print(f"Package: {PACKAGE}")
     print(f"Project: {OWNER}/{PROJECT}")

--- a/scripts/trigger_builds.py
+++ b/scripts/trigger_builds.py
@@ -228,10 +228,10 @@ def main() -> None:
     ]
 
     if args.no_monitor:
-        print(f"\nBuild #{result.id} submitted. Use --no-monitor to skip waiting.")
+        print(f"\nBuild #{result.id} submitted.")
         return
 
-    print(f"\nMonitoring build #{result.id} ...\n")
+    print(f"\nMonitoring build #{result.id}...  Use --no-monitor to skip waiting.\n")
     if not monitor_builds(client, submitted, args.poll_interval):
         sys.exit("\nBuild did not succeed.")
 

--- a/scripts/trigger_builds.py
+++ b/scripts/trigger_builds.py
@@ -137,7 +137,8 @@ def monitor_builds(client: Client, builds: list[dict], poll_interval: float) -> 
     return all(b["state"] == "succeeded" for b in builds)
 
 
-def main() -> None:
+def parse_args() -> argparse.Namespace:
+    targeter = Targeter()
     parser = argparse.ArgumentParser(
         description="Trigger COPR builds for goose across all chroots.",
     )
@@ -179,10 +180,14 @@ def main() -> None:
         "chroots",
         nargs="*",
         help="Chroots to build for. If not specified, all chroots are used.",
-        default=CHROOTS,
+        default=targeter.chroots,
+        choices=targeter.chroots,
     )
-    args = parser.parse_args()
+    return parser.parse_args()
 
+
+def main() -> None:
+    args = parse_args()
     chroots = args.chroots
 
     print(f"Package: {PACKAGE}")

--- a/scripts/trigger_builds.py
+++ b/scripts/trigger_builds.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Trigger COPR builds for goose in @rhel-lightspeed/goose.
+
+Each target runs with no options, which means that the builds take quite a bit
+longer since the checks run during build.
+
+Authentication requires a ~/.config/copr file or COPR_LOGIN, COPR_TOKEN, COPR_USERNAME env vars.
+"""
+
+import argparse
+import os
+import sys
+import time
+
+from pathlib import Path
+
+from copr.v3 import Client
+from copr.v3 import CoprRequestException
+from copr.v3.exceptions import CoprAuthException
+from copr.v3.exceptions import CoprConfigException
+from rich.live import Live
+from rich.table import Table
+
+
+OWNER = "@rhel-lightspeed"
+PROJECT = "goose"
+PACKAGE = "goose"
+
+CHROOTS = [
+    "fedora-43-x86_64",
+    "fedora-43-aarch64",
+    "fedora-43-ppc64le",
+    "fedora-43-s390x",
+    "fedora-44-x86_64",
+    "fedora-44-aarch64",
+    "fedora-44-ppc64le",
+    "fedora-44-s390x",
+    "fedora-rawhide-x86_64",
+    "fedora-rawhide-aarch64",
+    "fedora-rawhide-ppc64le",
+    "fedora-rawhide-s390x",
+    "epel-9-x86_64",
+    "epel-9-aarch64",
+    "epel-9-ppc64le",
+    "epel-9-s390x",
+    "epel-10-x86_64",
+    "epel-10-aarch64",
+    "epel-10-ppc64le",
+    "epel-10-s390x",
+    "rhel-9-x86_64",
+    "rhel-9-aarch64",
+    "rhel-9-s390x",
+    "rhel-10-x86_64",
+    "rhel-10-aarch64",
+    "rhel-10-s390x",
+    "rhel-10-ppc64le",
+]
+
+TERMINAL_STATES = {"succeeded", "failed", "canceled", "forked"}
+
+STATE_STYLES = {
+    "succeeded": "[bold green]succeeded[/]",
+    "failed": "[bold red]failed[/]",
+    "canceled": "[dim]canceled[/]",
+    "forked": "[dim]forked[/]",
+    "running": "[bold yellow]running[/]",
+    "starting": "[yellow]starting[/]",
+    "importing": "[yellow]importing[/]",
+    "pending": "[dim yellow]pending[/]",
+    "waiting": "[dim]waiting[/]",
+}
+
+
+def create_client(config_file: Path | None = None) -> Client:
+    login = os.environ.get("COPR_LOGIN")
+    token = os.environ.get("COPR_TOKEN")
+
+    if login and token:
+        return Client(
+            {
+                "copr_url": os.environ.get("COPR_URL", "https://copr.fedorainfracloud.org"),
+                "login": login,
+                "token": token,
+                "username": os.environ.get("COPR_USERNAME"),
+            }
+        )
+
+    try:
+        return Client.create_from_config_file(config_file)
+    except CoprConfigException as exc:
+        sys.exit(f"ERROR: {exc}")
+
+
+def _format_duration(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    h, m = divmod(m, 60)
+    if h:
+        return f"{h}h {m}m {s}s"
+
+    return f"{m}m {s}s" if m else f"{s}s"
+
+
+def _build_table(builds: list[dict]) -> Table:
+    table = Table(title="COPR Build Status", title_style="bold cyan")
+    table.add_column("Build ID", justify="right")
+    table.add_column("Chroots", max_width=60)
+    table.add_column("State", justify="center")
+    table.add_column("Duration", justify="right")
+
+    now = time.monotonic()
+    for b in builds:
+        state = b["state"]
+        elapsed = b.get("finished_at", now) - b["submitted_at"]
+        table.add_row(
+            str(b["build_id"]),
+            ", ".join(b["chroots"]),
+            STATE_STYLES.get(state, f"[dim]{state}[/]"),
+            _format_duration(elapsed),
+        )
+
+    return table
+
+
+def monitor_builds(client: Client, builds: list[dict], poll_interval: float) -> bool:
+    try:
+        with Live(_build_table(builds), refresh_per_second=2) as live:
+            while True:
+                for b in builds:
+                    if b["state"] in TERMINAL_STATES:
+                        continue
+                    try:
+                        b["state"] = client.build_proxy.get(b["build_id"]).state
+                        if b["state"] in TERMINAL_STATES:
+                            b["finished_at"] = time.monotonic()
+                    except CoprRequestException:
+                        pass
+                live.update(_build_table(builds))
+                if all(b["state"] in TERMINAL_STATES for b in builds):
+                    break
+                time.sleep(poll_interval)
+    except KeyboardInterrupt:
+        print("\nInterrupted.")
+
+        return False
+
+    return all(b["state"] == "succeeded" for b in builds)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Trigger COPR builds for goose across all chroots.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Show what would be built without triggering.",
+    )
+    parser.add_argument(
+        "--no-monitor",
+        action="store_true",
+        help="Submit builds without waiting for results.",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        "-S",
+        type=float,
+        default=30.0,
+        metavar="S",
+        help="Seconds between status polls (default: 30).",
+    )
+    parser.add_argument(
+        "--timeout",
+        "-t",
+        type=int,
+        default=36000,
+        metavar="S",
+        help="Build timeout in seconds (default: 36000).",
+    )
+    parser.add_argument(
+        "--config",
+        "-c",
+        type=Path,
+        default=None,
+        help="Path to Copr config file.",
+    )
+    parser.add_argument(
+        "chroots",
+        nargs="*",
+        help="Chroots to build for. If not specified, all chroots are used.",
+    )
+    args = parser.parse_args()
+
+    chroots = args.chroots or CHROOTS
+
+    print(f"Package: {PACKAGE}")
+    print(f"Project: {OWNER}/{PROJECT}")
+    print(f"Chroots ({len(chroots)}):")
+    for chroot in chroots:
+        print(f"  - {chroot}")
+
+    client = create_client(args.config)
+
+    if args.dry_run:
+        print("\nDry-run mode: no builds triggered.")
+        return
+
+    print(f"\nTriggering build for {PACKAGE} ...", flush=True)
+    try:
+        result = client.package_proxy.build(
+            OWNER,
+            PROJECT,
+            PACKAGE,
+            buildopts={"chroots": chroots, "timeout": args.timeout},
+        )
+        print(f"Build submitted (#{result.id})")
+    except (CoprRequestException, CoprAuthException) as exc:
+        sys.exit(f"FAILED: {exc}")
+
+    submitted = [
+        {
+            "build_id": result.id,
+            "state": "pending",
+            "submitted_at": time.monotonic(),
+            "chroots": chroots,
+        }
+    ]
+
+    if args.no_monitor:
+        print(f"\nBuild #{result.id} submitted. Use --no-monitor to skip waiting.")
+        return
+
+    print(f"\nMonitoring build #{result.id} ...\n")
+    if not monitor_builds(client, submitted, args.poll_interval):
+        sys.exit("\nBuild did not succeed.")
+
+    print("\nBuild succeeded.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trigger_builds.py
+++ b/scripts/trigger_builds.py
@@ -9,9 +9,11 @@ Authentication requires a ~/.config/copr file or COPR_LOGIN, COPR_TOKEN, COPR_US
 """
 
 import argparse
+import dataclasses
 import os
 import sys
 import time
+import typing as t
 
 from pathlib import Path
 
@@ -27,22 +29,6 @@ OWNER = "@rhel-lightspeed"
 PROJECT = "goose"
 PACKAGE = "goose"
 
-FEDORA_MAJOR_VERSIONS = ("43", "44", "rawhide")
-RHEL_MAJOR_VERSIONS = ("9", "10")
-ARCH = (
-    "x86_64",
-    "aarch64",
-    "s390x",
-    "ppc64le",
-    "s390x",
-)
-TARGETS = (
-    *[f"fedora-{ver}" for ver in FEDORA_MAJOR_VERSIONS],
-    *[f"{dist}-{ver}" for dist in ("epel", "rhel") for ver in RHEL_MAJOR_VERSIONS],
-)
-CHROOTS = [f"{target}-{arch}" for target in TARGETS for arch in ARCH]
-
-
 TERMINAL_STATES = {"succeeded", "failed", "canceled", "forked"}
 
 STATE_STYLES = {
@@ -56,6 +42,24 @@ STATE_STYLES = {
     "pending": "[dim yellow]pending[/]",
     "waiting": "[dim]waiting[/]",
 }
+
+
+@dataclasses.dataclass(frozen=True)
+class Targeter:
+    """Build chroots based on versions and architectures."""
+
+    fedora_versions: t.Iterable[str] = ("43", "44", "rawhide")
+    rhel_versions: t.Iterable[str] = ("9", "10")
+    architectures: t.Iterable[str] = ("x86_64", "aarch64", "s390x", "ppc64le", "s390x")
+    chroots: t.Iterable[str] = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        targets = [
+            *[f"fedora-{ver}" for ver in self.fedora_versions],
+            *[f"{dist}-{ver}" for dist in ("epel", "rhel") for ver in self.rhel_versions],
+        ]
+        chroots = [f"{target}-{arch}" for target in targets for arch in self.architectures]
+        super().__setattr__("chroots", chroots)
 
 
 def create_client(config_file: Path | None = None) -> Client:


### PR DESCRIPTION
Add a job that runs all the builds on a schedule. Because it takes about four hours to run the build with checks, those checks are disabled for PR and merge changes.

Add tooling to freeze requirements used for running the job to prevent spontaneous breakage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit support for Python 3.14 in dependency management and tooling.

* **Chores**
  * Scheduled weekly (and manual) Copr builds for automated package releases.
  * Added a CLI tool and Makefile target to generate pinned dependency lockfiles for multiple Python versions.
  * Pinned build dependencies and updated linting/formatting configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rhel-lightspeed/goose/pull/28)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->