### PR TITLE
[RSPEED-2970] Use cargo-vendor-fiter for vendor tarball

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,7 @@ actions:
   # The last setp here is required by Packit to return the archive name
   # https://packit.dev/docs/configuration/actions#create-archive
   create-archive:
+    - bash -c "cargo install cargo-vendor-filterer@0.5.18"
     - bash -c "./generate-vendor-tarball.sh"
     - bash -c "ls -1 goose*.tar.xz"
   # We fix the first source of the specfile because packit just understands

--- a/generate-vendor-tarball.sh
+++ b/generate-vendor-tarball.sh
@@ -68,7 +68,7 @@ export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
 rm -rf vendor
 
 echo "[+] Generating vendor folder (Linux-only via cargo-vendor-filterer)..."
-cargo vendor-filterer "${PLATFORM_ARGS[@]}" --versioned-dirs >/dev/null 2>&1
+cargo vendor-filterer "${PLATFORM_ARGS[@]}" --versioned-dirs
 
 echo "[+] Generating tarball of vendor folder..."
 tar Jcf "../$NAME-$VERSION-vendor.tar.xz" vendor/ >/dev/null 2>&1

--- a/generate-vendor-tarball.sh
+++ b/generate-vendor-tarball.sh
@@ -47,8 +47,28 @@ for patch in "${PATCHES[@]}"; do
     echo "[!] Applied patch $patch"
 done
 
-echo "[+] Generating vendor folder..."
-cargo vendor --versioned-dirs >/dev/null 2>&1
+
+# Target platforms matching Fedora/EPEL build architectures
+PLATFORMS=(
+    x86_64-unknown-linux-gnu
+    aarch64-unknown-linux-gnu
+    s390x-unknown-linux-gnu
+    powerpc64le-unknown-linux-gnu
+)
+
+PLATFORM_ARGS=()
+for platform in "${PLATFORMS[@]}"; do
+    PLATFORM_ARGS+=("--platform=$platform")
+done
+
+# Ensure ~/.cargo/bin is in PATH (cargo install places binaries there)
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+
+# Remove the in-tree vendor/v8 shim to avoid conflicts with cargo-vendor-filterer
+rm -rf vendor
+
+echo "[+] Generating vendor folder (Linux-only via cargo-vendor-filterer)..."
+cargo vendor-filterer "${PLATFORM_ARGS[@]}" --versioned-dirs >/dev/null 2>&1
 
 echo "[+] Generating tarball of vendor folder..."
 tar Jcf "../$NAME-$VERSION-vendor.tar.xz" vendor/ >/dev/null 2>&1


### PR DESCRIPTION
This reduces the size of the vendored tarball by removing (almost all) windows/macos crates from the final vendor folder.

Difference between using vendor-filter and not using it: 

```bash
vendor-filter:
59M -rw-r--r--. 1 rolivier rolivier  59M May 11 08:26 goose-1.23.2-vendor.tar.xz

non-vendor-filter:
116M -rw-r--r--. 1 rolivier rolivier 116M May 11 08:27 goose-1.23.2-vendor.tar.xz
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vendor dependency generation to use an enhanced vendor-generation tool (added an install step), produce multi-target vendored artifacts for x86_64, aarch64, s390x and powerpc64le, ensure a clean vendor directory, and preserve archive packaging and cleanup — improving cross-platform build compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rhel-lightspeed/goose/pull/29)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->