### PR TITLE
Ensure timeout and poll values are positive

### DIFF
--- a/scripts/trigger_builds.py
+++ b/scripts/trigger_builds.py
@@ -10,6 +10,7 @@ Authentication requires a ~/.config/copr file or COPR_LOGIN, COPR_TOKEN, COPR_US
 
 import argparse
 import dataclasses
+import math
 import os
 import sys
 import time
@@ -137,20 +138,30 @@ def monitor_builds(client: Client, builds: list[dict], poll_interval: float) -> 
     return all(b["state"] == "succeeded" for b in builds)
 
 
-def positive_number(value: str | int | float) -> int | float:
-    message = f"Value must be a positive int or float: {value}"
-    try:
-        value = int(value)
-    except ValueError:
+def positive_float(value: str | float) -> float:
+    if not isinstance(value, float):
+        exception = argparse.ArgumentTypeError(f"Value must be a positive float: {value}")
         try:
             value = float(value)
         except ValueError:
-            raise argparse.ArgumentTypeError(message)
-    except TypeError:
-        raise argparse.ArgumentTypeError(message)
+            raise exception
 
-    if value <= 0:
-        raise argparse.ArgumentTypeError(f"Value must be positive: {value}")
+        if value <= 0 or not math.isfinite(value):
+            raise exception
+
+    return value
+
+
+def positive_int(value: str | int) -> int:
+    if not isinstance(value, int):
+        exception = argparse.ArgumentTypeError(f"Value must be a positive integer: {value}")
+        try:
+            value = int(value)
+        except (ValueError, TypeError):
+            raise exception
+
+        if value <= 0:
+            raise exception
 
     return value
 
@@ -174,7 +185,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--poll-interval",
         "-S",
-        type=positive_number,
+        type=positive_float,
         default=30.0,
         metavar="S",
         help="Seconds between status polls (default: 30).",
@@ -182,7 +193,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--timeout",
         "-t",
-        type=positive_number,
+        type=positive_int,
         default=36000,
         metavar="S",
         help="Build timeout in seconds (default: 36000).",

--- a/scripts/trigger_builds.py
+++ b/scripts/trigger_builds.py
@@ -137,6 +137,24 @@ def monitor_builds(client: Client, builds: list[dict], poll_interval: float) -> 
     return all(b["state"] == "succeeded" for b in builds)
 
 
+def positive_number(value: str | int | float) -> int | float:
+    message = f"Value must be a positive int or float: {value}"
+    try:
+        value = int(value)
+    except ValueError:
+        try:
+            value = float(value)
+        except ValueError:
+            raise argparse.ArgumentTypeError(message)
+    except TypeError:
+        raise argparse.ArgumentTypeError(message)
+
+    if value <= 0:
+        raise argparse.ArgumentTypeError(f"Value must be positive: {value}")
+
+    return value
+
+
 def parse_args() -> argparse.Namespace:
     targeter = Targeter()
     parser = argparse.ArgumentParser(
@@ -156,7 +174,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--poll-interval",
         "-S",
-        type=float,
+        type=positive_number,
         default=30.0,
         metavar="S",
         help="Seconds between status polls (default: 30).",
@@ -164,7 +182,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--timeout",
         "-t",
-        type=int,
+        type=positive_number,
         default=36000,
         metavar="S",
         help="Build timeout in seconds (default: 36000).",


### PR DESCRIPTION
Add functions to ensure timeout and poll values are positive int and float values, respectively.

```
> ./scripts/trigger_builds.py -n -S -1.5
usage: trigger_builds.py [-h] [--dry-run] [--no-monitor] [--poll-interval S] [--timeout S] [--config CONFIG]
                         [{fedora-43-x86_64,fedora-43-aarch64,fedora-43-s390x,fedora-43-ppc64le,fedora-44-x86_64,fedora-44-aarch64,fedora-44-s390x,fedora-44-ppc64le,fedora-rawhide-x86_64,fedora-rawhide-aarch64,fedora-rawhide-s390x,fedora-rawhide-ppc64le,epel-9-x86_64,epel-9-aarch64,epel-9-s390x,epel-9-ppc64le,epel-10-x86_64,epel-10-aarch64,epel-10-s390x,epel-10-ppc64le,rhel-9-x86_64,rhel-9-aarch64,rhel-9-s390x,rhel-9-ppc64le,rhel-10-x86_64,rhel-10-aarch64,rhel-10-s390x,rhel-10-ppc64le} ...]
trigger_builds.py: error: argument --poll-interval/-S: Value must be a positive float: -1.5

> ./scripts/trigger_builds.py -n -t 1.5
usage: trigger_builds.py [-h] [--dry-run] [--no-monitor] [--poll-interval S] [--timeout S] [--config CONFIG]
                         [{fedora-43-x86_64,fedora-43-aarch64,fedora-43-s390x,fedora-43-ppc64le,fedora-44-x86_64,fedora-44-aarch64,fedora-44-s390x,fedora-44-ppc64le,fedora-rawhide-x86_64,fedora-rawhide-aarch64,fedora-rawhide-s390x,fedora-rawhide-ppc64le,epel-9-x86_64,epel-9-aarch64,epel-9-s390x,epel-9-ppc64le,epel-10-x86_64,epel-10-aarch64,epel-10-s390x,epel-10-ppc64le,rhel-9-x86_64,rhel-9-aarch64,rhel-9-s390x,rhel-9-ppc64le,rhel-10-x86_64,rhel-10-aarch64,rhel-10-s390x,rhel-10-ppc64le} ...]
trigger_builds.py: error: argument --timeout/-t: Value must be a positive integer: 1.5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI validation for `--poll-interval` to reject non-positive or non-finite values.
  * Improved CLI validation for `--timeout` to reject non-positive values, ensuring only valid numeric inputs are accepted.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rhel-lightspeed/goose/pull/32)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->