### PR TITLE
[RSPEED-3050] Add patch to force update to latest openssl version

### DIFF
--- a/0006-Update-openssl-transitive-dependency.patch
+++ b/0006-Update-openssl-transitive-dependency.patch
@@ -1,0 +1,32 @@
+--- a/Cargo.lock	2026-05-14 09:01:07.232523296 -0300
++++ b/Cargo.lock	2026-05-14 09:03:00.491541402 -0300
+@@ -4749,15 +4749,14 @@
+ 
+ [[package]]
+ name = "openssl"
+-version = "0.10.75"
++version = "0.10.79"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
++checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+ dependencies = [
+  "bitflags 2.10.0",
+  "cfg-if",
+  "foreign-types",
+  "libc",
+- "once_cell",
+  "openssl-macros",
+  "openssl-sys",
+ ]
+@@ -4781,9 +4780,9 @@
+ 
+ [[package]]
+ name = "openssl-sys"
+-version = "0.9.111"
++version = "0.9.115"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
++checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+ dependencies = [
+  "cc",
+  "libc",

--- a/generate-vendor-tarball.sh
+++ b/generate-vendor-tarball.sh
@@ -2,7 +2,12 @@
 set -euo pipefail
 
 # List of patches to be applied in the vendored folder
-PATCHES=("0000-Patch-windows-dependencies-across-workspace.patch" "0001-Disable-rustls-and-default-features-for-some-librari.patch" "0003-Fix-for-CVE-2026-33056-on-tar.patch")
+PATCHES=(
+    "0000-Patch-windows-dependencies-across-workspace.patch" 
+    "0001-Disable-rustls-and-default-features-for-some-librari.patch" 
+    "0003-Fix-for-CVE-2026-33056-on-tar.patch" 
+    "0006-Update-openssl-transitive-dependency.patch"
+)
 
 check_required_tools() {
     local tools=("cargo" "rpmspec" "spectool" "tar" "patch")
@@ -43,7 +48,7 @@ rm -rf "$GOOSE_SOURCE" && tar xf "$GOOSE_SOURCE_TARBALL" >/dev/null 2>&1
 echo "[+] Applying patches..."
 pushd "$GOOSE_SOURCE" >/dev/null
 for patch in "${PATCHES[@]}"; do
-    patch -p1 <"../$patch" >/dev/null 2>&1
+    patch -p1 <"../$patch" 
     echo "[!] Applied patch $patch"
 done
 

--- a/goose.spec
+++ b/goose.spec
@@ -83,6 +83,11 @@ Patch4:         0004-Fix-sql-statement-from-session-manager.patch
 # Backport of https://github.com/aaif-goose/goose/pull/8118
 # Sets permissions of newly created secrets.yaml file to 0600.
 Patch5:         0005-Better-default-permissions-for-secrets.patch
+# Update a transitive dependency for openssl to fix CVEs:
+#   * CVE-2026-41676, CVE-2026-41677, CVE-2026-41678, 
+#   * CVE-2026-41681, CVE-2026-41898, CVE-2026-42327, 
+#   * CVE-2026-44662
+Patch6:         0006-Update-openssl-transitive-dependency.patch
 
 ## Downstream only patches
 #


### PR DESCRIPTION
There are quite a few CVEs released for the openssl crate recently, so we are introducing this downstream patch to force it to pull the newest version, avoiding the CVEs that got released recently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenSSL-related Rust crate versions and lockfile checksums.
  * Improved vendor tarball generation to list patches clearly and show patch application output.
* **Security**
  * Added a downstream RPM patch to roll up OpenSSL transitive dependency updates addressing multiple CVEs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rhel-lightspeed/goose/pull/34)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->