### PR TITLE
Run goose-tests for each PR

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -94,3 +94,30 @@ jobs:
     # in case.
     timeout: 36000
     targets: *targets
+
+  # Run internal test suite on Testing Farm (Red Hat ranch)
+  - job: tests
+    trigger: pull_request
+    fmf_url: "https://gitlab.cee.redhat.com/rhel-lightspeed/enhanced-shell/goose-tests"
+    fmf_ref: "main"
+    use_internal_tf: True
+    identifier: goose-tests
+    env:
+      GOOSE_TESTS_GOOSE_REDHAT_PACKAGE_SOURCE_PROFILE: "copr"
+    targets:
+      # Run the x86_64 archs only for pull requests. This is faster and "economical" than having all other architectures as well.
+      # We rarely see issues on other architectures, we only run them on a weekly basis inside the "rhel-lightspeed/enhanced-shell/goose-tests" repository as a scheduled pipeline.
+      rhel-10-x86_64:
+        distros:
+          - RHEL-10.2-Nightly
+          - RHEL-10.3-Nightly
+      rhel-9-x86_64:
+        distros:
+          - RHEL-9.8.0-Nightly
+          - RHEL-9.9.0-Nightly
+    tf_extra_params:
+      environments:
+        - settings:
+            provisioning:
+              tags:
+                BusinessUnit: rhel_sst_lightspeed@upstream


### PR DESCRIPTION
Run only on x86. The other archs will run in weekly scheduled pipeline inside the goose-tests repository.

Ref: https://redhat.atlassian.net/browse/RSPEED-3030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated testing job that runs on RHEL 9 and RHEL 10 x86_64 (nightly) to validate changes.
* **Chores**
  * CI configuration updated to execute tests via an external testing service and provision test environments with required tags/parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rhel-lightspeed/goose/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->