### PR TITLE
[RSPEED-3122] Test against the "develop" branch for packit tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -99,9 +99,10 @@ jobs:
   - job: tests
     trigger: pull_request
     fmf_url: "https://gitlab.cee.redhat.com/rhel-lightspeed/enhanced-shell/goose-tests"
-    fmf_ref: "main"
+    fmf_ref: "develop"
     use_internal_tf: True
     identifier: goose-tests
+    tmt_plan: "level0"
     env:
       GOOSE_TESTS_GOOSE_REDHAT_PACKAGE_SOURCE_PROFILE: "copr"
     targets:


### PR DESCRIPTION
Test against the "develop" branch for packit tests.

Ref: https://redhat.atlassian.net/browse/RSPEED-3122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal testing configuration: the CI test job that runs for pull requests now uses a different test-suite branch/ref to align PR test runs with ongoing development. This adjusts which test definitions are used when validating contributions and helps ensure PRs are checked against the latest development test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->