### PR TITLE
Improve build tools and update documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ NAME := goose
 PKG_NAME := $(NAME)
 TOOL2RPM := rust2rpm
 FAS_USERNAME := $(shell copr whoami)
+DIST_GIT_CHECKOUT ?= ../goose-fedora
+VERSION := $(shell rpmspec -q --qf "%{VERSION}" goose.spec)
+VENDOR_TARBALL := goose-$(VERSION)-vendor.tar.xz
+SRPM = $(shell srpm=$$(ls goose-$(VERSION)*.src.rpm 2>/dev/null | tail -n 1); if [ -f "$$srpm" ]; then echo $$(realpath "$$srpm"); else echo MISSING; fi)
 
 .PHONY: create-copr-repo
 create-copr-repo:
@@ -13,9 +17,23 @@ create-copr-repo:
 sources:
 	spectool -g $(NAME).spec
 
-.PHONY: srpm
-srpm:
+# Dynamic targets that will not run if the file exists.
+$(VENDOR_TARBALL):
+	./generate-vendor-tarball.sh
+
+$(SRPM):
 	fedpkg --release rawhide srpm
+
+# Static targets that provide a consistent interface.
+.PHONY: vendor-tarball
+vendor-tarball: $(VENDOR_TARBALL)
+
+.PHONY: srpm
+srpm: vendor-tarball $(SRPM)
+
+.PHONY: import
+import: srpm
+	@(cd $(DIST_GIT_CHECKOUT) && fedpkg import $(SRPM))
 
 .PHONY: build
 build: srpm
@@ -63,7 +81,7 @@ logs:
 
 .PHONY: clean
 clean:
-	rm -rf *.src.rpm *.tar.gz *.tar.xz *.crate vendor
+	rm -rf *.src.rpm *.tar.gz *.tar.xz *.crate vendor goose-*
 
 .PHONY: freeze
 freeze:

--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ Before executing a new build, run the initial setup first:
 ```bash
 # Create a new copr repository
 make create-copr-repo
-
-# Will create a specfile based on project settings.
-# This is only needed in case the goose.spec is missing.
-make spec
 ```
 
 ## Building

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -38,14 +38,38 @@ files are placed in the repository root directory.
 make sources
 ```
 
+### `vendor-tarball`
+
+Generates the vendored crate tarball using `generate-vendor-tarball.sh`. This
+is a prerequisite of the `srpm` target and is skipped if the tarball already
+exists.
+
+```bash
+make vendor-tarball
+```
+
 ### `srpm`
 
 Generates a source RPM (`.src.rpm`) using `fedpkg` targeting the Rawhide
-release. This is automatically called by the `build` target, but can be run
-independently to verify that the spec file produces a valid SRPM.
+release. Depends on `vendor-tarball` to ensure the vendored crate tarball
+exists first. This is automatically called by the `build` target, but can be
+run independently to verify that the spec file produces a valid SRPM.
 
 ```bash
 make srpm
+```
+
+### `import`
+
+Imports the SRPM into the dist-git checkout directory. Depends on `srpm` to
+ensure the SRPM exists. Runs `fedpkg import` inside the directory specified
+by the `DIST_GIT_CHECKOUT` variable (defaults to `../goose-fedora`).
+
+```bash
+make import
+
+# Or with a custom dist-git checkout path
+make import DIST_GIT_CHECKOUT=/path/to/dist-git
 ```
 
 ### `build`
@@ -56,6 +80,16 @@ Builds the package in COPR. This target first generates an SRPM (via the
 
 ```bash
 make build
+```
+
+### `build-all`
+
+Builds the package in COPR across all supported chroots: Fedora 43, 44, and
+Rawhide (x86_64, aarch64, ppc64le, s390x), EPEL 9 and 10, and RHEL 9 and 10.
+Uses a 10-hour timeout.
+
+```bash
+make build-all
 ```
 
 ### `logs`
@@ -77,6 +111,7 @@ Removes generated build artifacts from the repository root:
 - `*.tar.gz`, `*.tar.xz` -- source tarballs
 - `*.crate` -- Rust crate archives
 - `vendor/` -- vendored dependencies directory
+- `goose-*` -- extracted source and vendor directories
 
 ```bash
 make clean
@@ -91,6 +126,15 @@ under `requirements/`.
 ```bash
 make freeze
 ```
+
+## Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DIST_GIT_CHECKOUT` | `../goose-fedora` | Path to the dist-git checkout used by `make import`. Override with `make import DIST_GIT_CHECKOUT=/path/to/checkout`. |
+| `SRPM` | Auto-detected | Resolves to the absolute path of the most recent `.src.rpm` in the repo root, or `MISSING` if none exists. |
+| `VERSION` | From spec | Extracted from `goose.spec` using `rpmspec`. |
+| `VENDOR_TARBALL` | `goose-$(VERSION)-vendor.tar.xz` | Name of the vendored crate tarball. |
 
 ## Typical Workflow
 

--- a/generate-vendor-tarball.sh
+++ b/generate-vendor-tarball.sh
@@ -42,12 +42,20 @@ if [ ! -f "$GOOSE_SOURCE_TARBALL" ]; then
 fi
 
 echo "[+] Tarball found, extracting..."
-rm -rf "$GOOSE_SOURCE" && tar xf "$GOOSE_SOURCE_TARBALL" >/dev/null 2>&1
+rm -rf "$GOOSE_SOURCE"
+tar -xzf "$GOOSE_SOURCE_TARBALL" \
+    --exclude "goose-${VERSION}/.claude" \
+    --exclude "goose-${VERSION}/.codex" \
+    --exclude "goose-${VERSION}/.cursor" \
+    --exclude "goose-${VERSION}/evals" \
+    --exclude "goose-${VERSION}/services" \
+    --exclude "goose-${VERSION}/oidc-proxy" \
+    --exclude "goose-${VERSION}/vendor/v8"
 
 echo "[+] Applying patches..."
 pushd "$GOOSE_SOURCE" >/dev/null
 for patch in "${PATCHES[@]}"; do
-    patch -p1 <"../$patch" 
+    patch -p1 <"../$patch"
     echo "[!] Applied patch $patch"
 done
 


### PR DESCRIPTION
Add make targets to generate vendor tarball, create srpm, and import sources.

Use dynamic targets based on the version to determine if the target needs to run.
Static aliases are used to provide a consistent interface.

```
make vendor-tarball
make srpm
make import
```

The SRPM variable is [recursively expanded](https://www.gnu.org/software/make/manual/html_node/Recursive-Assignment.html) since it may change when the srpm target runs.

Running `make import` will build the vendor tarball, build the srpm, and then import it into the dist-git repo.

There's still a bit of work to do with making sure the dist-git repo is in the correct state to import the srpm. The changes to the dist-git repo then need to be submitted in a PR. That isn't covered in these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified setup instructions by removing manual build steps.
  * Updated build system documentation with new targets and configuration options.

* **Chores**
  * Enhanced build automation with centralized version and artifact management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->