### PR TITLE
Fix s390x compilation failures in Copr environment

### DIFF
--- a/goose.spec
+++ b/goose.spec
@@ -25,6 +25,13 @@
 %constrain_build -m 6144
 
 %global rustflags_codegen_units 16
+# WORKAROUND: Mitigate flaky ICE in Rust 1.92 on s390x in COPR environment
+# by reducing concurrent LLVM threads and memory footprint during code generation.
+%ifarch s390x
+  %if 0%{?copr_projectname:1}
+    %global build_rustflags -Copt-level=3 -Cdebuginfo=0 -Ccodegen-units=1 -Cstrip=none --cap-lints=warn
+  %endif
+%endif
 
 Name:           goose
 Version:        1.36.0


### PR DESCRIPTION
This PR addresses persistent s390x build failures, OOM and rustc ICE, in constrained Copr build environments.

-  Copr s390x builders are constrained 2CPUs VMs with limitted RAM, forcing the default 16 concurrent LLVM threads overwhelms the memory, causing ICE.  Therefore, in spec: mitigate flaky ICE on s390x in COPR environment commit we override default `%build_rustflags` to force `codegen-units=1` and `debuginfo=0`.
 
All compiler and linker mitigations in this PR are strictly fenced behind `%if  0%{?copr_projectname:1}` and `%ifarch s390x`. While there are trade-backs in build speed and runtime performance, these are acceptable because they only apply to Copr builds. Our primary goal here is to achieve stable, reliable builds for development testing and QA CI automation,  where a consistent "Success" status is strictly necessary to prevent pipeline blockers. Production Koji builds (which run on far more powerful HW) remain unaffected by these limits.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability for certain `s390x` COPR builds by applying a conditional Rust compilation fallback.
  * Reduced the chance of build-time compiler crashes by lowering code generation pressure and memory usage in affected builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->